### PR TITLE
Add CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,34 +3,28 @@
 *.lo
 *.o
 *.obj
-
 # Precompiled Headers
 *.gch
 *.pch
-
 # Compiled Dynamic libraries
 *.so
 *.dylib
 *.dll
-
 # Fortran module files
 *.mod
 *.smod
-
 # Compiled Static libraries
 *.lai
 *.la
 *.a
 *.lib
-
 # Executables
 *.exe
 *.out
 *.app
-
-# emacs 
+# emacs
 *~
-
 # others
 core
 su2
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright © 2017 Martin Ueding <dev@martin-ueding.de>
+# Licensed under the GNU Public License version 3
+
+cmake_minimum_required(VERSION 2.8.11)
+project(su2 C CXX)
+
+# There is one header file which is in a subdirectory. This add the `-i` to the
+# compiler.
+include_directories("include")
+
+# We could just have two `add_executable` blocks listing almost all source
+# files. However, CMake would then compile the source files twice, once for
+# each executable. The rationale is that different flags can be used for
+# different executables. Here we want to re-use this. One can either track the
+# generated objects files or create a simple static library. The latter is done
+# here.
+add_library(su2
+    gauge_energy.cc
+    gaugeconfig.cc
+    get_staples.cc
+    random_gauge_trafo.cc
+    su2.cc
+    sweep.cc
+)
+
+# Create the main program.
+add_executable(su2-main main.cc)
+target_link_libraries(su2-main su2)
+
+# Create the test driver.
+add_executable(su2-test test.cc)
+target_link_libraries(su2-test su2)

--- a/init-cmake-build.sh
+++ b/init-cmake-build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright © 2017 Martin Ueding <dev@martin-ueding.de>
+# Licensed under the GNU Public License version 3
+
+set -e
+set -u
+
+if [[ -d build ]]; then
+    echo "Directory build exists, this script will do nothing."
+    exit 1
+fi
+
+mkdir -p build/debug
+mkdir -p build/release
+
+pushd build/debug
+cmake ../.. -DCMAKE_BUILD_TYPE=Debug
+popd
+
+pushd build/release
+cmake ../.. -DCMAKE_BUILD_TYPE=Release
+popd


### PR DESCRIPTION
This adds CMake support for this project. The original `Makefile` is left as-is.

Builds are done in subdirectories if desired. Run the `init-cmake-build.sh` script to create a `Makefile` in `build/debug` (with `-g` in the `CXXFLAGS`) and a second one in `build/release` (with `-O3`). This way one can have both builds around without having to call `make clean` and making changes to the `Makefile`.